### PR TITLE
fix: migrate from Container Registry to Artifact Registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Configure Docker for GCR
-        run: gcloud auth configure-docker
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev
 
       - name: Create .env file
         run: |

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,6 +5,7 @@ set -eu
 PROJECT_ID=$PROJECT_ID
 REGION="asia-northeast1"
 SERVICE_NAME="mapsllm"
+REPOSITORY_NAME="docker"
 
 # Load environment variables from .env file
 if [ -f .env ]; then
@@ -15,14 +16,14 @@ else
 fi
 
 # Build the container with platform specification
-docker build --platform linux/amd64 -t gcr.io/$PROJECT_ID/$SERVICE_NAME .
+docker build --platform linux/amd64 -t $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY_NAME/$SERVICE_NAME .
 
-# Push to Google Container Registry
-docker push gcr.io/$PROJECT_ID/$SERVICE_NAME
+# Push to Artifact Registry
+docker push $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY_NAME/$SERVICE_NAME
 
 # Deploy to Cloud Run
 gcloud run deploy $SERVICE_NAME \
-  --image gcr.io/$PROJECT_ID/$SERVICE_NAME \
+  --image $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY_NAME/$SERVICE_NAME \
   --platform managed \
   --region $REGION \
   --project $PROJECT_ID \


### PR DESCRIPTION
Resolves #3 - Deploy workflow failure due to Container Registry deprecation

## Changes
- Updated deploy.sh to use Artifact Registry format
- Added REPOSITORY_NAME configuration variable
- Changed Docker image references from gcr.io to asia-northeast1-docker.pkg.dev

## Required Manual Steps
1. Create Artifact Registry repository:
   `gcloud artifacts repositories create docker --repository-format=docker --location=asia-northeast1 --project=YOUR_PROJECT_ID`

2. If using GitHub Actions, update Docker authentication in workflows:
   `gcloud auth configure-docker asia-northeast1-docker.pkg.dev`

🤖 Generated with [Claude Code](https://claude.ai/code)